### PR TITLE
fix: Use open instead of opn (deprecated)

### DIFF
--- a/bin/good-first-issue.js
+++ b/bin/good-first-issue.js
@@ -2,7 +2,7 @@
 
 var cli = require('commander')
 var chalk = require('chalk')
-var opn = require('opn')
+var open = require('open')
 
 var pJson = require('../package.json')
 
@@ -60,7 +60,7 @@ cli
     console.log(output.toString())
 
     if (cmd.open) {
-      opn(issues[key].url)
+      open(issues[key].url)
       process.exit(0)
     }
   })

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "chalk": "^2.4.1",
     "commander": "^2.19.0",
     "inquirer": "^6.2.0",
-    "opn": "^5.4.0"
+    "open": "^6.3.0"
   },
   "devDependencies": {
     "jest": "^24.8.0",


### PR DESCRIPTION
[opn](https://npmjs.com/package/opn) was renamed to [open](https://npmjs.com/package/open) recently. 
Made the required updates within the code-base.