### PR TITLE
Add azure-pipelines.yml

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,47 @@
+jobs:
+  - job: Build
+    strategy:
+      matrix:
+        linux_node_8:
+          imageName: ubuntu-16.04
+          node_version: 8.x
+        linux_node_10:
+          imageName: ubuntu-16.04
+          node_version: 10.x
+        linux_node_12:
+          imageName: ubuntu-16.04
+          node_version: 12.x
+        mac_node_8: 
+          imageName: macos-10.13
+          node_version: 8.x
+        mac_node_10:
+          imageName: macos-10.13
+          node_version: 10.x
+        mac_node_12:
+          imageName: macos-10.13
+          node_version: 12.x
+        windows_node_8: 
+          imageName: vs2017-win2016
+          node_version: 8.x
+        windows_node_10:
+          imageName: vs2017-win2016
+          node_version: 10.x
+        windows_node_12:
+          imageName: vs2017-win2016
+          node_version: 12.x
+
+    pool:
+      vmImage: $(imageName)
+
+    steps:
+    - task: NodeTool@0 
+      inputs:
+        versionSpec: $(node_version)
+
+    - script: |
+        npm install
+        npm test
+      displayName: 'npm install and build'
+  
+trigger:
+    - master


### PR DESCRIPTION
This adds `azure-pipelines.yml`, the app for which has already been added to the repo. Jenkins hasn't been working and I'm not particularly keen on how new management has handled things post-[acquisition](https://techcrunch.com/2019/01/23/idera-acquires-travis-ci/).

More than open to having additional build systems if anyone wants to add them – I'm just interested in learning Pipelines since it's been getting a lot more widespread adoption in the JavaScript ecosystem as of late.