### PR TITLE
refactor: remove unnecessary async keyword

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ const search = require('./lib/search')
 
 const projects = require('./data/projects.json')
 
-module.exports = async function (project) {
+module.exports = project => {
   if (project in projects) {
     return search(projects[project].q)
   } else {


### PR DESCRIPTION
From [docs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function#Description), if no `await` is present in a function the execution is not paused and code will then be executed synchronously.

`search` itself returns a promise, and so all the `async` keyword would do in this case would be to make the function automatically return an (extra) Promise that's resolved when the function returns. There would thus have been two promises needing resolution, which wouldn't have changed end-user behavior since if you `await` nested promises, it will keep `await`ing until everything resolves.

This just removes that extra `async`.

cc @bnb 