### PR TITLE
Adding Yarn Version Manager and RichTextView to projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,19 +134,21 @@ The table of projects which are _currently_ supported.
 |31.|React Native|`react-native`|A framework for building native apps with React.|
 |32.|React Navigation|`react-navigation`|Routing and navigation for your React Native apps.|
 |33.|Rebus|`rebus`|Take your first steps as an open source contributor |
-|34.|scikit-learn|`scikit-learn`|scikit-learn: machine learning in Python|
-|35.|Scrapy|`scrapy`|A fast high-level web crawling & scraping framework for Python.|
-|36.|Spring Cloud GCP|`spring-cloud-gcp`|Integration for Google Cloud Platform APIs with Spring|
-|37.|Strapi|`strapi`|Open source Node.js Headless CMS to easily build customisable APIs.|
-|38.|Storybook|`storybook`|Storybook is an open source tool for developing UI components in isolation for React, Vue, and Angular. It makes building stunning UIs organized and efficient.|
-|39.|Styled Components|`styled-components`|Visual primitives for the component age. Use the best bits of ES6 and CSS to style your apps without stress.|
-|40.|TypeScript|`typescript`|TypeScript is a superset of JavaScript that compiles to clean JavaScript output.|
-|41.|VS Code|`vscode`|VS Code is a type of tool that combines the simplicity of a code editor with what developers need for their core edit-build-debug cycle.|
-|42.|webpack CLI|`webpack-cli`|webpack CLI provides a flexible set of commands for developers to increase speed when setting up a custom webpack project.|
-|43.|wolkenkit|`wolkenkit`|wolkenkit is an open-source CQRS and event-sourcing framework for JavaScript and Node.js that perfectly matches DDD. |
-|44.|Verdaccio|`verdaccio`|A lightweight private npm proxy registry|
-|45.|Vue.js|`vuejs`|Vue.js is a progressive, incrementally-adoptable JavaScript framework for building UI on the web.|
-|46.|Yarn|`yarn`|Fast, reliable, and secure dependency management.|
+|34.|RichTextView|`richtextview`|iOS text view (UIView) that properly displays LaTeX, HTML, Markdown, and YouTube/Vimeo links|
+|35.|scikit-learn|`scikit-learn`|scikit-learn: machine learning in Python|
+|36.|Scrapy|`scrapy`|A fast high-level web crawling & scraping framework for Python.|
+|37.|Spring Cloud GCP|`spring-cloud-gcp`|Integration for Google Cloud Platform APIs with Spring|
+|38.|Strapi|`strapi`|Open source Node.js Headless CMS to easily build customisable APIs.|
+|39.|Storybook|`storybook`|Storybook is an open source tool for developing UI components in isolation for React, Vue, and Angular. It makes building stunning UIs organized and efficient.|
+|40.|Styled Components|`styled-components`|Visual primitives for the component age. Use the best bits of ES6 and CSS to style your apps without stress.|
+|41.|TypeScript|`typescript`|TypeScript is a superset of JavaScript that compiles to clean JavaScript output.|
+|42.|VS Code|`vscode`|VS Code is a type of tool that combines the simplicity of a code editor with what developers need for their core edit-build-debug cycle.|
+|43.|webpack CLI|`webpack-cli`|webpack CLI provides a flexible set of commands for developers to increase speed when setting up a custom webpack project.|
+|44.|wolkenkit|`wolkenkit`|wolkenkit is an open-source CQRS and event-sourcing framework for JavaScript and Node.js that perfectly matches DDD. |
+|45.|Verdaccio|`verdaccio`|A lightweight private npm proxy registry|
+|46.|Vue.js|`vuejs`|Vue.js is a progressive, incrementally-adoptable JavaScript framework for building UI on the web.|
+|47.|Yarn|`yarn`|Fast, reliable, and secure dependency management.|
+|48.|Yarn Version Manager|`yvm`|YVM is a version manager for yarn that makes it easy to handle projects with differing yarn versions.|
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## Adding New Projects

--- a/data/projects.json
+++ b/data/projects.json
@@ -164,6 +164,11 @@
     "q": "repo:ollelauribostrom/rebus label:\"good first issue\" state:open",
     "description": "Take your first steps as an open source contributor "
   },
+  "richtextview": {
+    "name": "RichTextView",
+    "q": "repo:tophat/richtextview is:issue is:open label:\"good first issue\"",
+    "description": "iOS text view (UIView) that properly displays LaTeX, HTML, Markdown, and YouTube/Vimeo links"
+  },
   "scikit-learn": {
     "name": "scikit-learn",
     "q": "repo:scikit-learn/scikit-learn is:issue is:open sort:updated-desc label:\"good first issue\"",
@@ -228,5 +233,10 @@
     "name": "Yarn",
     "q": "repo:yarnpkg/yarn is:issue is:open sort:updated-desc label:\"good first issue\"",
     "description": "Fast, reliable, and secure dependency management."
+  },
+  "yvm": {
+    "name": "Yarn Version Manager",
+    "q": "repo:tophat/yvm is:issue is:open label:\"good first issue\"",
+    "description": "YVM is a version manager for yarn that makes it easy to handle projects with differing yarn versions."
   }
 }


### PR DESCRIPTION
This issue-aggregation project is really cool! I think it can be extremely useful for people to find issues to swarm on and for projects to gain exposure. In this spirit, I'd like to add two projects maintained by the organization I'm part of to the mix: [RichTextView](https://github.com/tophat/RichTextView) and [Yarn Version Manager](https://github.com/tophat/yvm).

Let me know what you think!

