### PR TITLE
feat: add support for authenticated requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,20 +9,22 @@ A CLI for finding issues labeled with Good First Issue to help lower the barrier
 
 <!-- toc -->
 
-- [Prerequisites](#prerequisites)
-- [Usage](#usage)
-  * [Installation](#installation)
-  * [Commands](#commands)
-  * [CLI Options](#cli-options)
-- [TODOs: What's coming up next](#todos-whats-coming-up-next)
-- [Projects](#projects)
-- [Adding New Projects](#adding-new-projects)
-  * [Adding New Projects: More Information](#adding-new-projects-more-information)
-- [Release Process](#release-process)
-  * [Versioning](#versioning)
-- [Labels and Milestones](#labels-and-milestones)
-  * [Local Testing](#local-testing)
-- [Contributing](#contributing)
+- [Good First Issue](#good-first-issue)
+  - [Table of Contents](#table-of-contents)
+  - [Prerequisites](#prerequisites)
+  - [Usage](#usage)
+    - [Installation](#installation)
+    - [Commands](#commands)
+    - [CLI Options](#cli-options)
+  - [TODOs: What's coming up next](#todos-whats-coming-up-next)
+  - [Projects](#projects)
+  - [Adding New Projects](#adding-new-projects)
+    - [Adding New Projects: More Information](#adding-new-projects-more-information)
+  - [Release Process](#release-process)
+    - [Versioning](#versioning)
+  - [Labels and Milestones](#labels-and-milestones)
+    - [Local Testing](#local-testing)
+  - [Contributing](#contributing)
 
 <!-- tocstop -->
 
@@ -67,6 +69,7 @@ good-first-issue # call the CLI
 
 - `-o, --open` - open in browser
 - `-f, --first` - Return first/top issue
+- `-a, --auth <github personal access token>` - Authenticate with the GitHub API (increased rate limits)
 
 ## TODOs: What's coming up next
 

--- a/bin/good-first-issue.js
+++ b/bin/good-first-issue.js
@@ -10,17 +10,22 @@ const log = require('../lib/log')
 const prompt = require('../lib/prompt')
 const projects = require('../data/projects.json')
 
-const options = { // options for libgfi
-  projects
-}
-
 cli
   .version(packageJSON.version, '-v, --version')
   .description(packageJSON.description)
   .arguments('[project]')
   .option('-o, --open', 'Open in browser')
   .option('-f, --first', 'Return first/top issue')
+  .option('-a, --auth <token>', 'Authenticate with the GitHub API (increased rate limits)')
   .action(async (project, cmd) => {
+    const options = { // options for libgfi
+      projects: projects
+    }
+
+    if (cmd.auth) {
+      options.auth = cmd.auth
+    }
+
     let input = project
 
     if (!project) {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "chalk": "^3.0.0",
     "commander": "^4.0.1",
     "inquirer": "^7.0.0",
-    "libgfi": "^1.0.2",
+    "libgfi": "^1.1.1",
     "open": "^7.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
adds support for authenticated requests via the `--auth` flag which will unlock the ability to land #180 