### PR TITLE
improvement: enable require access

### DIFF
--- a/bin/good-first-issue.js
+++ b/bin/good-first-issue.js
@@ -10,7 +10,7 @@ const log = require('../lib/log')
 const prompt = require('../lib/prompt')
 const projects = require('../data/projects.json')
 
-cli
+module.exports = cli
   .version(packageJSON.version, '-v, --version')
   .description(packageJSON.description)
   .arguments('[project]')
@@ -58,4 +58,7 @@ cli
       process.exitCode = 1
     }
   })
-  .parse(process.argv)
+
+if (require.main && require.main.filename === __filename) {
+  module.exports.parse(process.argv)
+}

--- a/lib/main.js
+++ b/lib/main.js
@@ -1,0 +1,2 @@
+
+module.exports = require('../bin/good-first-issue')

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "good-first-issue",
   "version": "0.27.2",
   "description": "A CLI for finding good-first-issues in open source projects.",
-  "main": "index.js",
+  "main": "lib/main.js",
   "scripts": {
     "toc": "npx markdown-toc -i readme.md",
     "markdown": "npx markdown-magic",

--- a/tests/main.spec.js
+++ b/tests/main.spec.js
@@ -1,0 +1,22 @@
+const cli = require('commander')
+
+describe('main', () => {
+
+  const excuteTests = (main) => {
+    test('should foo', () => {
+      expect(main)
+        .toBeInstanceOf(cli.Command)
+    })
+  }
+
+  describe("when using package's main", () => {
+    const main = require('..')
+    excuteTests(main)
+  })
+
+  describe('when using lib/main.js', () => {
+    const main = require('../lib/main.js')
+    excuteTests(main)
+  })
+
+})


### PR DESCRIPTION
This will enable the module to be required as it were a
normal library, which will allow programmatic access to the API.

```js
// require as module
const goodFirstIssue = require('good-first-issue')

// execute the bin script
goodFirstIssue.parse([ ... args ])
```