### PR TITLE
Fix Error with 'docusaurus': output issues aren't always from docusaurus #193

### DIFF
--- a/data/projects.json
+++ b/data/projects.json
@@ -21,7 +21,7 @@
   },
   "docusaurus": {
     "name": "Docusaurus",
-    "q": "org:facebook is:issue is:open label:\"good first issue\"",
+    "q": "repo:facebook/docusaurus is:issue is:open label:\"good first issue\"",
     "description": "Easy to maintain open source documentation websites. "
   },
   "docz": {


### PR DESCRIPTION
## Type of PR

- [x] Bug Fix

## Description

This PR fixes the issue #193: changes the query for docusaurus so it only shows issues from docusaurus instead of the whole facebook organization.

## Related Ticket
#193 