### PR TITLE
fix: Addresses deprecation warning for Octokit usage

### DIFF
--- a/lib/search.js
+++ b/lib/search.js
@@ -1,6 +1,7 @@
 // This helper goes and fetches Good First Issues
 // This module expects a search query which is just a standard GitHub search query. These queries should not include sort or order, since those are defined in the function.
-const octokit = require('@octokit/rest')()
+const { Octokit } = require('@octokit/rest')
+const octokit = new Octokit()
 
 /// GitHub search parameters for the Node.js org
 const SORT = 'updated'

--- a/tests/search.spec.js
+++ b/tests/search.spec.js
@@ -6,11 +6,15 @@ beforeEach(() => {
   jest.restoreAllMocks()
   jest.resetAllMocks()
   issuesAndPullRequests = jest.fn()
-  jest.doMock('@octokit/rest', () => () => {
+  jest.doMock('@octokit/rest', () => {
     return {
-      search: {
-        issuesAndPullRequests
-      }
+      Octokit: jest.fn().mockImplementation(() => {
+        return {
+          search: {
+            issuesAndPullRequests
+          }
+        }
+      })
     }
   })
   search = require('../lib/search')


### PR DESCRIPTION
This addresses the deprecation warnings for the Octokit usage that was mentioned in #195. 