### PR TITLE
test: cover module entrypoint behavior

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,8 @@
+const gfi = require('libgfi')
+
+const projects = require('./data/projects.json')
+
+module.exports = (project, options = {}) => gfi(project, {
+  projects,
+  ...options
+})

--- a/tests/cli-open.spec.js
+++ b/tests/cli-open.spec.js
@@ -1,0 +1,81 @@
+const issue = {
+  title: 'Open browser for the selected issue',
+  pr: 12,
+  state: 'open',
+  url: 'https://github.com/cutenode/good-first-issue/issues/12',
+  labels: [],
+  assignee: null,
+  assignees: [],
+  locked: false
+}
+
+const mockGfi = jest.fn(() => Promise.resolve([issue]))
+const mockOpen = jest.fn()
+const mockLog = jest.fn(() => Promise.resolve('formatted output'))
+
+jest.mock('libgfi', () => mockGfi)
+jest.mock('open', () => mockOpen)
+jest.mock('../lib/log', () => mockLog)
+
+jest.mock('commander', () => {
+  let actionHandler
+  const cli = {
+    version: jest.fn(() => cli),
+    description: jest.fn(() => cli),
+    arguments: jest.fn(() => cli),
+    option: jest.fn(() => cli),
+    action: jest.fn(handler => {
+      actionHandler = handler
+      return cli
+    }),
+    parse: jest.fn(async argv => {
+      const args = argv.slice(2)
+      const options = {
+        open: args.includes('--open'),
+        first: args.includes('--first'),
+        auth: null
+      }
+      const project = args.find(arg => !arg.startsWith('-'))
+      return actionHandler(project, options)
+    })
+  }
+
+  return cli
+})
+
+describe('good-first-issue CLI', () => {
+  const originalArgv = process.argv
+  const originalExitCode = process.exitCode
+  const originalConsoleLog = console.log
+  const originalConsoleError = console.error
+
+  beforeEach(() => {
+    jest.resetModules()
+    process.argv = ['node', 'good-first-issue', 'react', '--open']
+    process.exitCode = undefined
+    console.log = jest.fn()
+    console.error = jest.fn()
+    mockGfi.mockClear()
+    mockOpen.mockClear()
+    mockLog.mockClear()
+  })
+
+  afterAll(() => {
+    process.argv = originalArgv
+    process.exitCode = originalExitCode
+    console.log = originalConsoleLog
+    console.error = originalConsoleError
+  })
+
+  test('opens the selected issue URL and exits cleanly with --open', async () => {
+    require('../bin/good-first-issue')
+    await new Promise(resolve => setImmediate(resolve))
+
+    expect(mockGfi).toHaveBeenCalledWith('react', expect.objectContaining({
+      projects: expect.any(Object)
+    }))
+    expect(mockLog).toHaveBeenCalledWith(issue, 'React')
+    expect(mockOpen).toHaveBeenCalledWith(issue.url)
+    expect(process.exitCode).toBe(0)
+  })
+})

--- a/tests/index.spec.js
+++ b/tests/index.spec.js
@@ -1,0 +1,20 @@
+jest.mock('libgfi', () => jest.fn(() => Promise.resolve([])))
+
+const gfi = require('libgfi')
+const projects = require('../data/projects.json')
+const goodFirstIssue = require('../index')
+
+beforeEach(() => {
+  gfi.mockClear()
+})
+
+test('should export a working libgfi wrapper with bundled projects', async () => {
+  const customOptions = { auth: 'token-123', first: true }
+
+  await goodFirstIssue('react', customOptions)
+
+  expect(gfi).toHaveBeenCalledWith('react', {
+    projects,
+    ...customOptions
+  })
+})

--- a/tests/log.spec.js
+++ b/tests/log.spec.js
@@ -36,3 +36,21 @@ test('should return formatted log', async () => {
 
     expect(expectedOutput).toBe(stripAnsi(actualOutput))
 })
+
+test('should not include undefined in formatted output', async () => {
+    const issue = {
+        title: 'Clarify repo output',
+        pr: 456,
+        labels: [],
+        state: 'open',
+        url: 'https://github.com/cutenode/good-first-issue/issues/456',
+        assignee: null,
+        assignees: [],
+        locked: false
+    }
+
+    const actualOutput = await log(issue, 'Good First Issue')
+
+    expect(stripAnsi(actualOutput)).toContain('Repository: cutenode/good-first-issue')
+    expect(stripAnsi(actualOutput)).not.toContain('undefined')
+})


### PR DESCRIPTION
## Summary
- restore the missing `index.js` module entrypoint as a thin `libgfi` wrapper that injects the bundled project map
- add a regression test that proves `require('good-first-issue')` calls `libgfi` with the packaged project data
- extend the formatter coverage to assert the repo name is rendered without `undefined`

## Testing
- npm test

Related to #1.