### PR TITLE
fix: show friendly GitHub API failure messages

### DIFF
--- a/bin/good-first-issue.js
+++ b/bin/good-first-issue.js
@@ -54,7 +54,14 @@ cli
         process.exitCode = 0
       }
     } catch (err) {
-      console.error(err)
+      const message = [
+        `\nUnable to fetch issues for "${input}".`,
+        /rate limit/i.test(err.message)
+          ? 'Please check the project name, your network connection, or your GitHub API rate limit.\n'
+          : 'Please check the project name or your network connection.\n'
+      ].join('\n')
+
+      console.error(chalk.red(message))
       process.exitCode = 1
     }
   })

--- a/tests/cli-error.spec.js
+++ b/tests/cli-error.spec.js
@@ -1,0 +1,36 @@
+jest.mock('libgfi', () => jest.fn())
+
+const gfi = require('libgfi')
+
+const originalArgv = process.argv.slice()
+const originalExitCode = process.exitCode
+
+afterEach(() => {
+  jest.resetModules()
+  jest.clearAllMocks()
+  process.argv = originalArgv.slice()
+  process.exitCode = originalExitCode
+})
+
+test('shows a friendly message when the GitHub API request fails', async () => {
+  gfi.mockRejectedValue(Object.assign(new Error('API rate limit exceeded for 127.0.0.1.'), {
+    status: 403
+  }))
+
+  const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+
+  process.argv = ['node', 'bin/good-first-issue.js', 'thisisntarealprojectorgithuborg']
+
+  delete require.cache[require.resolve('../bin/good-first-issue')]
+  require('../bin/good-first-issue')
+
+  await new Promise(resolve => setImmediate(resolve))
+
+  expect(errorSpy).toHaveBeenCalledWith(
+    expect.stringContaining('Unable to fetch issues for "thisisntarealprojectorgithuborg".')
+  )
+  expect(errorSpy).toHaveBeenCalledWith(
+    expect.stringContaining('Please check the project name, your network connection, or your GitHub API rate limit.')
+  )
+  expect(process.exitCode).toBe(1)
+})


### PR DESCRIPTION
## Summary
- replace the raw error dump with a friendly CLI message when fetching issues fails
- mention rate limiting explicitly for GitHub API 403 failures
- add a regression test for rejected GitHub API requests

## Testing
- npm test

Closes #1039