### PR TITLE
docs: fix typo in local testing section

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ Prior to each release, whoever is releasing should be testing the release locall
 
 It is worth noting that we limit the file we publish to npm with the `files` property in [`package.json`](https://github.com/bnb/good-first-issue/blob/master/package.json). This property prevents code that's not explicitly listed from being shipped. We have had a situation where local testing and the published module differed because a PR was merged that added needed code in a directory that wasn't included. So, what works on your machine may not work for the end user.
 
-To test locally, using the modules tests with `npm test` and trying out a few different commands (like the selector, a specific project, a failed project, and so on) is reccomended. For example:
+To test locally, using the module tests with `npm test` and trying out a few different commands (like the selector, a specific project, a failed project, and so on) is recommended. For example:
 
 ```text
 npm i -g # This assumes your current working directory is the module's directory


### PR DESCRIPTION
Fixes #1080.

## Summary
- Corrected reccomended to recommended in the README Local Testing section.

This is a docs-only typo cleanup to improve clarity and polish of contributor guidance.