### PR TITLE
docs: fix README typos and grammar

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,9 +186,9 @@ Once a PR is ready to be released, a milestone will be added that correlates to 
 
 Prior to each release, whoever is releasing should be testing the release locally to ensure that the code is working as expected. This would include either running `npm i -g` or `npm link` in the PR branch and then testing whatever the PR is adding. Ensuring the experience isn't broken is vital.
 
-It is worth noting that we limit the file we publish to npm with the `files` property in [`package.json`](https://github.com/bnb/good-first-issue/blob/master/package.json). This property prevents code that's not explicitly listed from being shipped. We have had a situation where local testing and the published module differed because a PR was merged that added needed code in a directory that wasn't included. So, what works on your machine may not work for the end user.
+It is worth noting that we limit the file we publish to npm with the `files` property in [`package.json`](https://github.com/bnb/good-first-issue/blob/master/package.json). This property prevents code that's not explicitly listed from being shipped. We have had a situation where local testing and the published module differed because a PR was merged that added needed code in a directory that wasn't included. So what works on your machine may not work for the end user.
 
-To test locally, using the modules tests with `npm test` and trying out a few different commands (like the selector, a specific project, a failed project, and so on) is reccomended. For example:
+To test locally, using the module's tests with `npm test` and trying out a few different commands (like the selector, a specific project, a failed project, and so on) is recommended. For example:
 
 ```text
 npm i -g # This assumes your current working directory is the module's directory


### PR DESCRIPTION
## Summary

This PR fixes a couple of minor issues in the README:

* Corrected a spelling mistake: `reccomended` → `recommended`
* Corrected a grammar issue: `modules tests` → `module's tests`

These changes improve readability and clarity without changing functionality.