### PR TITLE
feat: add custom label flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,11 +64,13 @@ good-first-issue # call the CLI
 - `good-first-issue [project]`: you can pass in a name from the [list of projects](#projects) which is a curated list of projects that have been verified to have good-first-issues.
 - `good-first-issue [GitHub organization or user]`: similar to `[project]` but will search any GitHub organization or user that exists for issues labeled with "Good First Issue".
 - `good-first-issue [GitHub organization or user]/[repo]`: similar to `[project]`, but will search a specific repository on GitHub within the organization for issues labeled with "Good First Issue".
+- `good-first-issue [target] --label "help wanted"`: search the same target using a custom label instead of the default "Good First Issue".
 
 ### CLI Options
 
 - `-o, --open` - open in browser
 - `-f, --first` - Return first/top issue
+- `-l, --label <label>` - Search using a custom issue label such as `help wanted` or `first-timers-only`
 - `-a, --auth <github personal access token>` - Authenticate with the GitHub API (increased rate limits)
 
 ## TODOs: What's coming up next

--- a/bin/good-first-issue.js
+++ b/bin/good-first-issue.js
@@ -9,6 +9,10 @@ const packageJSON = require('../package.json')
 const log = require('../lib/log')
 const prompt = require('../lib/prompt')
 const projects = require('../data/projects.json')
+const {
+  buildDirectSearchQuery,
+  replaceLabelInProjectQuery
+} = require('../lib/search-query')
 
 cli
   .version(packageJSON.version, '-v, --version')
@@ -16,6 +20,7 @@ cli
   .arguments('[project]')
   .option('-o, --open', 'Open in browser')
   .option('-f, --first', 'Return first/top issue')
+  .option('-l, --label <label>', 'Search using a custom issue label')
   .option('-a, --auth <token>', 'Authenticate with the GitHub API (increased rate limits)')
   .action(async (project, cmd) => {
     const options = { // options for libgfi
@@ -31,6 +36,26 @@ cli
     if (!project) {
       console.log('')
       input = await prompt()
+    }
+
+    if (cmd.label) {
+      if (input in projects) {
+        options.projects = {
+          ...projects,
+          [input]: {
+            ...projects[input],
+            q: replaceLabelInProjectQuery(projects[input].q, cmd.label)
+          }
+        }
+      } else {
+        options.projects = {
+          ...projects,
+          [input]: {
+            name: input,
+            q: buildDirectSearchQuery(input, cmd.label)
+          }
+        }
+      }
     }
 
     try {

--- a/lib/search-query.js
+++ b/lib/search-query.js
@@ -1,0 +1,26 @@
+const DEFAULT_LABEL = 'good first issue'
+
+function formatLabelQuery (label = DEFAULT_LABEL) {
+  return `label:${JSON.stringify(label)}`
+}
+
+function buildDirectSearchQuery (project, label = DEFAULT_LABEL) {
+  const scope = project.includes('/') ? 'repo' : 'org'
+  return `${scope}:${project} state:open ${formatLabelQuery(label)}`
+}
+
+function replaceLabelInProjectQuery (query, label = DEFAULT_LABEL) {
+  const positiveLabelPattern = /(^|\s)label:("[^"]+"|[^\s]+)/i
+
+  if (positiveLabelPattern.test(query)) {
+    return query.replace(positiveLabelPattern, `$1${formatLabelQuery(label)}`)
+  }
+
+  return `${query} ${formatLabelQuery(label)}`
+}
+
+module.exports = {
+  DEFAULT_LABEL,
+  buildDirectSearchQuery,
+  replaceLabelInProjectQuery
+}

--- a/tests/search-query.spec.js
+++ b/tests/search-query.spec.js
@@ -1,0 +1,33 @@
+const {
+  DEFAULT_LABEL,
+  buildDirectSearchQuery,
+  replaceLabelInProjectQuery
+} = require('../lib/search-query')
+
+test('buildDirectSearchQuery uses the default label for org searches', () => {
+  expect(buildDirectSearchQuery('nodejs')).toBe(
+    `org:nodejs state:open label:${JSON.stringify(DEFAULT_LABEL)}`
+  )
+})
+
+test('buildDirectSearchQuery uses the provided label for repo searches', () => {
+  expect(buildDirectSearchQuery('cutenode/good-first-issue', 'help wanted')).toBe(
+    'repo:cutenode/good-first-issue state:open label:"help wanted"'
+  )
+})
+
+test('replaceLabelInProjectQuery swaps the primary label query', () => {
+  const query = 'repo:babel/babel is:issue is:open label:"good first issue" -label:"Has PR" -label:"claimed"'
+
+  expect(replaceLabelInProjectQuery(query, 'help wanted')).toBe(
+    'repo:babel/babel is:issue is:open label:"help wanted" -label:"Has PR" -label:"claimed"'
+  )
+})
+
+test('replaceLabelInProjectQuery appends the label when none exists', () => {
+  const query = 'repo:example/project is:issue is:open sort:updated-desc'
+
+  expect(replaceLabelInProjectQuery(query, 'first-timers-only')).toBe(
+    'repo:example/project is:issue is:open sort:updated-desc label:"first-timers-only"'
+  )
+})


### PR DESCRIPTION
## Summary
- add a `--label` / `-l` CLI option for custom issue-label searches
- reuse the flag for both curated project queries and direct org/repo searches
- document the option in the README and cover the query building in tests

## Testing
- npm test

Closes #1085